### PR TITLE
Remove field_order to fix install

### DIFF
--- a/erpnext_app_store/erpnext_app_store/doctype/application/application.json
+++ b/erpnext_app_store/erpnext_app_store/doctype/application/application.json
@@ -4,11 +4,6 @@
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
- "field_order": [
-  "title",
-  "description",
-  "link_to_github"
- ],
  "fields": [
   {
    "fieldname": "title",


### PR DESCRIPTION
:bug: :fire: Remove field_order to fix install error `ValueError: Document for field "field_order" attached to child table of "Application" must be a dict or BaseDocument, not class 'str' (title)`

Install details can be found on [Monogramm/docker-erpnext-poc_app_store Travis build](https://travis-ci.org/Monogramm/docker-erpnext-poc_app_store).